### PR TITLE
Footerのリンクのデザインを修正

### DIFF
--- a/src/app/_includes/layouts/default_layout/_footer.njk
+++ b/src/app/_includes/layouts/default_layout/_footer.njk
@@ -1,6 +1,4 @@
-<div class="flex items-center justify-center h-16 mt-auto bg-white border-t border-gray-200">
-  <div class="footer">
+<div class="flex items-center flex-col justify-center h-16 mt-auto bg-white border-t border-gray-200">
     <a>Footer</a>
     <a href="https://github.com/ookam/yaminabe" class="block text-blue-700 underline">GitHubリポジトリはこちら</a>
-  </div>
 </div>

--- a/src/app/_includes/layouts/default_layout/_footer.njk
+++ b/src/app/_includes/layouts/default_layout/_footer.njk
@@ -1,6 +1,6 @@
 <div class="flex items-center justify-center h-16 mt-auto bg-white border-t border-gray-200">
-  Footer
-  <div>
-    <a href="https://github.com/ookam/yaminabe">GitHubリポジトリはこちら</a>
+  <div class="footer">
+    <a>Footer</a>
+    <a href="https://github.com/ookam/yaminabe" class="block text-blue-700 underline">GitHubリポジトリはこちら</a>
   </div>
 </div>

--- a/src/packs/stylesheets/master.scss
+++ b/src/packs/stylesheets/master.scss
@@ -36,3 +36,9 @@ form{
 input{
     @apply appearance-none;
 }
+
+.footer{
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}

--- a/src/packs/stylesheets/master.scss
+++ b/src/packs/stylesheets/master.scss
@@ -36,9 +36,3 @@ form{
 input{
     @apply appearance-none;
 }
-
-.footer{
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-}


### PR DESCRIPTION
## このプルリクエストを一言で言うと
-Footerのリンクのデザインを修正しました。

## このプルリクエストを取り入れるとここが良くなるよ！
-リンクがFooterの文字列の横ではなく、下に表示されて綺麗
-リンクがリンクと認識してもらえる

## このプルリクエストを送ろうと思った理由/きっかけ！
-せっかくリンクにされているのに、ぱっと見気付けなかった為

## このプルリクエストのコードレビュー負荷は……

- [x] ★ 　　| 軽微 　| github上での目視コードレビューでOK
- [ ] ★★ 　| 中 　　| github上での目視コードレビューでOKだけど、それだとバグを見落とす可能性がちょっとある
- [ ] ★★★ | 超重要 | 手元でcheckoutして一通り確認が必要……大変……

## 特にここを重点的にレビューして欲しい！
src/packs/stylesheets/master.scssにclassを追加する運用が正しいか分からず対応してしまったので、適切じゃなければ指摘もらいたいです！

<!-- ロジック部分など、ちょっと自信がない部分、問題があった時に影響が大きそうな部分があったらここに記載しましょう！ -->
