### PR TITLE
#56の対応 feature: ダークモード切り替えボタンをスマートフォンタップ時にハイライトされないよう修正

### DIFF
--- a/src/app/_includes/layouts/default_layout/_header.njk
+++ b/src/app/_includes/layouts/default_layout/_header.njk
@@ -1,7 +1,7 @@
 <div class="relative flex items-center justify-center text-xl font-bold tracking-wider bg-white border-b border-gray-100 dark:border-gray-700 h-14 dark:bg-gray-800">
   <a href="{{ '/' | url}}" class="block" id='js-rainbox-text'>Welcome to Yaminabe</a>
   {# ダークモードの切り替えボタン #}
-  <div id="js-darkmode-text_ancestor" class='absolute z-10 flex items-center text-s top-2 bottom-2 right-3 cursor-pointer'>
+  <div class='absolute z-10 flex items-center text-s top-2 bottom-2 right-3 cursor-pointer tap-highlight-off'>
     <div class='px-1' onclick='window.toggleDarkMode()'>
       <span id="js-darkmode-text">灮</span>
     </div>

--- a/src/app/_includes/layouts/default_layout/_header.njk
+++ b/src/app/_includes/layouts/default_layout/_header.njk
@@ -1,7 +1,7 @@
 <div class="relative flex items-center justify-center text-xl font-bold tracking-wider bg-white border-b border-gray-100 dark:border-gray-700 h-14 dark:bg-gray-800">
   <a href="{{ '/' | url}}" class="block" id='js-rainbox-text'>Welcome to Yaminabe</a>
   {# ダークモードの切り替えボタン #}
-  <div class='absolute z-10 flex items-center text-s top-2 bottom-2 right-3 cursor-pointer'>
+  <div id="js-darkmode-text_ancestor" class='absolute z-10 flex items-center text-s top-2 bottom-2 right-3 cursor-pointer'>
     <div class='px-1' onclick='window.toggleDarkMode()'>
       <span id="js-darkmode-text">灮</span>
     </div>

--- a/src/packs/stylesheets/master.scss
+++ b/src/packs/stylesheets/master.scss
@@ -51,8 +51,3 @@ a{
         --isDarkmode: true;
     }
 }
-
-// タッチデバイスでクリックした際、ハイライトしない
-#js-darkmode-text_ancestor{
-    -webkit-tap-highlight-color: transparent;
-}

--- a/src/packs/stylesheets/master.scss
+++ b/src/packs/stylesheets/master.scss
@@ -51,3 +51,8 @@ a{
         --isDarkmode: true;
     }
 }
+
+// タッチデバイスでクリックした際、ハイライトしない
+#js-darkmode-text_ancestor{
+    -webkit-tap-highlight-color: transparent;
+}


### PR DESCRIPTION
## このプルリクエストを一言で言うと
- #56 【改善案】スマートフォンタップ時にハイライトされるのを無くしたい、の対応です。
## このプルリクエストを取り入れるとここが良くなるよ！
- ダークモードトグルボタンをクリック時、ハイライトされなくなりとてもcoolになります。

## このプルリクエストを送ろうと思った理由/きっかけ！
- この方が、coolだから。

## このプルリクエストのコードレビュー負荷は……

- [x] ★ 　　| 軽微 　| github上での目視コードレビューでOK
- [ ] ★★ 　| 中 　　| github上での目視コードレビューでOKだけど、それだとバグを見落とす可能性がちょっとある
- [ ] ★★★ | 超重要 | 手元でcheckoutして一通り確認が必要……大変……

## 特にここを重点的にレビューして欲しい！

<!-- ロジック部分など、ちょっと自信がない部分、問題があった時に影響が大きそうな部分があったらここに記載しましょう！ -->
