### PR TITLE
feature: コントリビュータの取得先のURLを修正

### DIFF
--- a/src/app/_data/contributors.js
+++ b/src/app/_data/contributors.js
@@ -3,10 +3,11 @@ var axios  = require('axios');
 module.exports = () => {
   return new Promise((resolve, reject) => {
     axios
-    .get("https://api.github.com/repos/ookam/yaminabe/contributors",
-    {
-      timeout : 10000,
-    }
+    .get(
+      "https://api.github.com/repos/ookam/yaminabe/contributors",
+      {
+        timeout : 10000,
+      }
     )
     .then((response) => {
       const data = []

--- a/src/app/_data/contributors.js
+++ b/src/app/_data/contributors.js
@@ -3,27 +3,26 @@ var axios  = require('axios');
 module.exports = () => {
   return new Promise((resolve, reject) => {
     axios
-      .get(
-        "https://api.github.com/repos/ookam/yaminabe/stats/contributors",
-        {
-          timeout : 10000,
-        }
-      )
-      .then((response) => {
-        const data = []
-        response.data.map((contributor) => {
-          data.push({
-            icon: contributor.author.avatar_url,
-            name: contributor.author.login,
-            url: contributor.author.html_url,
-            count: contributor.total,
-          })
+    .get("https://api.github.com/repos/ookam/yaminabe/contributors",
+    {
+      timeout : 10000,
+    }
+    )
+    .then((response) => {
+      const data = []
+      response.data.map((contributor) => {
+        data.push({
+          icon: contributor.avatar_url,
+          name: contributor.login,
+          url: contributor.html_url,
+          count: contributor.contributions,
         })
-        resolve(data)
       })
-      .catch((error) => {
-        console.error(error)
-        reject(error)
-      })
+      resolve(data)
     })
+    .catch((error) => {
+      console.error(error)
+      reject(error)
+    })
+  })
 }


### PR DESCRIPTION
## このプルリクエストを一言で言うと
- #55 【不具合】毎回CIが落ちる。原因が分かる方いたら助けて下さい！！！！、の対応です。
## このプルリクエストを取り入れるとここが良くなるよ！
- コントリビューター一覧取得が安定し、CIが落ちなくなる。

- 確かに一覧取得でdataが空で返ってくることがまれにあることを確認。
- 目的が単にコントリビュータの一覧を取得するのみなら、より単純に取得できるURLに変更してもいいのでは？と考え取得先URLを修正した。

## このプルリクエストを送ろうと思った理由/きっかけ！
- なるべくせせりさんに負担がかからない運用になってほしいから。

## このプルリクエストのコードレビュー負荷は……

- [x] ★ 　　| 軽微 　| github上での目視コードレビューでOK
- [ ] ★★ 　| 中 　　| github上での目視コードレビューでOKだけど、それだとバグを見落とす可能性がちょっとある
- [ ] ★★★ | 超重要 | 手元でcheckoutして一通り確認が必要……大変……

## 特にここを重点的にレビューして欲しい！

参照サイト
[list-repository-contributors](https://docs.github.com/en/rest/reference/repos#list-repository-contributors)
[get-all-contributor-commit-activity](https://docs.github.com/en/rest/reference/repos#get-all-contributor-commit-activity)
<!-- ロジック部分など、ちょっと自信がない部分、問題があった時に影響が大きそうな部分があったらここに記載しましょう！ -->
